### PR TITLE
Indigo-GM - Django 2.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
 
     python_requires='~=3.6',
     install_requires=[
+        'django>=2.2.12,<3',
         'indigo>=3',
         'requests>=2',
     ],


### PR DESCRIPTION
This PR adds `Django 2.2` as an explicit requirement.