### PR TITLE
Ignore 400 error when a country is unknown

### DIFF
--- a/indigo_gm/publications.py
+++ b/indigo_gm/publications.py
@@ -35,7 +35,7 @@ class GazetteMachinePublicationFinder(BasePublicationFinder):
             params['publication'] = publication
         headers = self.headers
         resp = requests.get(self.api_url + '/gazettes/archived/', params=params, timeout=self.timeout, headers=headers)
-        # bad country provided
+        # eg. bad country provided -- overly broad but it's a hack for now
         if resp.status_code == 400:
             return []
         resp.raise_for_status()

--- a/indigo_gm/publications.py
+++ b/indigo_gm/publications.py
@@ -35,6 +35,9 @@ class GazetteMachinePublicationFinder(BasePublicationFinder):
             params['publication'] = publication
         headers = self.headers
         resp = requests.get(self.api_url + '/gazettes/archived/', params=params, timeout=self.timeout, headers=headers)
+        # bad country provided
+        if resp.status_code == 400:
+            return []
         resp.raise_for_status()
 
         data = resp.json().get('results', [])


### PR DESCRIPTION
Hacky, but it'll have to do for now.

It would be better to get the GM API to just return an empty result set, but it's difficult for us to get django-filters to do the right thing in this case.